### PR TITLE
git SSH key gen script

### DIFF
--- a/gitSshKeyGen.sh
+++ b/gitSshKeyGen.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+NC='\033[0m' # No Color
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+
+if (( $# == 1 )); then
+  EMAIL=$1
+else
+  echo -e "${RED}Enter email as first argument${NC}"
+  exit
+fi
+
+ssh-keygen -t rsa -b 4096 -C $EMAIL
+
+eval "$(ssh-agent -s)"
+
+ssh-add ~/.ssh/id_rsa
+
+if hash xclip 2>/dev/null; then
+  echo -e "${GREEN}SSH Key coppied to clipboard${NC}"
+  xclip -selection c < ~/.ssh/id_rsa.pub
+  echo -e "${GREEN}[DONE]${NC}"
+  exit
+else
+  echo -e "${RED}xclip not installed${NC}"
+  echo -e "${GREEN}Coppy key from terminal${NC}"
+  cat ~/.ssh/id_rsa.pub
+  echo -e "${GREEN}[DONE]${NC}"
+  exit
+fi
+
+exit


### PR DESCRIPTION
This script will generate a new ssh key and copy it to your clipboard. Used for setting up git on new machines. I like to use git with ssh keys to save myself from always typing my username and password every time.