### PR TITLE
modified the shebangs for increased portability

### DIFF
--- a/oldmain.sh
+++ b/oldmain.sh
@@ -1,7 +1,7 @@
 # Turns your wallpaper into a live-STREAM of USU's Old Main.
 # Requires VLC.
 
-#!/bin/bash
+#!/usr/bin/env bash
 
 NC='\033[0m' # No Color
 GREEN='\033[0;32m'

--- a/push.sh
+++ b/push.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 function get_branch() {
   git branch --no-color | grep -E '^\*' | awk '{print $2}' \
     || echo "default_value"

--- a/sick_git_commands.sh
+++ b/sick_git_commands.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo -e "\e[31mgit log \e[0m// commit history"
 echo -e "\e[31mgit log \e[0m--pretty=oneline \e[0m// just do it"

--- a/timer.sh
+++ b/timer.sh
@@ -1,15 +1,15 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 spinner="\-/|"
 arg=$1
 printf "\n\n"
 for ((i=arg; i > 0; --i)); do
-sleep 1;
-if (( i < 10 )); then
-printf "\r0$i..${spinner:$(($i % 4)):1}";
-else
-printf "\r$i..${spinner:$(($i % 4)):1}";
-fi
+  sleep 1;
+  if (( i < 10 )); then
+    printf "\r0$i..${spinner:$(($i % 4)):1}";
+  else
+    printf "\r$i..${spinner:$(($i % 4)):1}";
+  fi
 done;
 printf "\nFinished!\n"
 

--- a/update.sh
+++ b/update.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 if hash pacman 2>/dev/null; then
   sudo pacman -Syyu

--- a/when_did_I_get_here.sh
+++ b/when_did_I_get_here.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # A lightweight tool for telling you how long you've been at work
 # Original author: Dave Browning


### PR DESCRIPTION
`#!/usr/bin/env bash` is more portable because it does not rely on the install location of bash. 